### PR TITLE
add tar in dependencies ensure installed

### DIFF
--- a/tasks/install_python.yml
+++ b/tasks/install_python.yml
@@ -11,6 +11,7 @@
     - pcre-devel
     - curl-devel
     - sqlite-devel
+    - tar
 
 - name: Check if python is already installed
   stat: path=/usr/local/bin/python2.7


### PR DESCRIPTION
My centos is in minimal version, there is no tar inside. It end up with the error below.

```
msg: Failed to find handler to unarchive. Make sure the required command to extract the file is installed.
```

Add tar to the dependencies will fix this.
